### PR TITLE
Fix link flag for oss-fuzz UBSAN builds

### DIFF
--- a/bazel/setup_configs.sh
+++ b/bazel/setup_configs.sh
@@ -137,6 +137,7 @@ if [ "$SANITIZER" = "address" ]; then
   echo "build:oss-fuzz --linkopt=-fsanitize=address"
 fi
 if [ "$SANITIZER" = "undefined" ]; then
+  echo "build:oss-fuzz --linkopt=-fsanitize=undefined"
   echo "build:oss-fuzz --linkopt=$(find $(llvm-config --libdir) -name libclang_rt.ubsan_standalone_cxx-x86_64.a | head -1)"
 fi
 if [ "$SANITIZER" = "coverage" ]; then


### PR DESCRIPTION
Follow up to https://github.com/google/fuzztest/pull/69 where a link flag is missing for UBSAN builds. This fixes it.

Signed-off-by: David Korczynski <david@adalogics.com>