### PR TITLE
Add support for Arbitrary<std::byte>

### DIFF
--- a/domain_tests/arbitrary_domains_test.cc
+++ b/domain_tests/arbitrary_domains_test.cc
@@ -90,6 +90,24 @@ TEST(ArbitraryBoolTest, InitGeneratesSeeds) {
                   .Times(Ge(650)));
 }
 
+TEST(ArbitraryByteTest, RepeatedMutationYieldsEveryValue) {
+  Domain<std::byte> domain = Arbitrary<std::byte>();
+  // Verify every value appears.
+  auto values = MutateUntilFoundN(domain, 256);
+  VerifyRoundTripThroughConversion(values, domain);
+  EXPECT_EQ(values.size(), 256);
+}
+
+TEST(ArbitraryByteTest, InitGeneratesSeeds) {
+  auto domain = Arbitrary<std::byte>().WithSeeds({std::byte{42}});
+
+  // With a 1000 tries, it's likely that any specific value will show up. To
+  // make this test meanigful, we expect to see the seed many more times than
+  // in a uniform distribution.
+  EXPECT_THAT(GenerateInitialValues(domain, 1000),
+              Contains(Value(domain, std::byte{42})).Times(Ge(350)));
+}
+
 struct MyStruct {
   int a;
   std::string s;

--- a/domain_tests/container_combinators_test.cc
+++ b/domain_tests/container_combinators_test.cc
@@ -62,7 +62,7 @@ class ContainerTest : public testing::Test {};
 
 using ContainerTypes = testing::Types<
     // Simple types
-    std::string, std::vector<int>, std::deque<int>,
+    std::string, std::vector<int>, std::deque<int>, std::vector<std::byte>,
     // Nested types
     std::vector<std::string>, std::list<std::vector<int>>,
     // Sets

--- a/domain_tests/domain_testing.h
+++ b/domain_tests/domain_testing.h
@@ -360,8 +360,12 @@ bool AreSame(const T& prev, const T& next) {
 
 template <typename T>
 bool TowardsZero(const T& prev, const T& next) {
-  if constexpr (std::numeric_limits<T>::is_integer || std::is_arithmetic_v<T> ||
-                std::is_enum_v<T>) {
+  if constexpr (std::is_same_v<std::byte, T> ||
+                std::is_same_v<const std::byte, T>) {
+    return TowardsZero(std::to_integer<unsigned char>(prev),
+                       std::to_integer<unsigned char>(next));
+  } else if constexpr (std::numeric_limits<T>::is_integer ||
+                       std::is_arithmetic_v<T> || std::is_enum_v<T>) {
     if constexpr (std::is_floating_point_v<T>) {
       // Ignore non-finites. Those never move towards zero.
       if (!std::isfinite(prev) || !std::isfinite(next)) return true;

--- a/fuzztest/internal/domains/arbitrary_impl.h
+++ b/fuzztest/internal/domains/arbitrary_impl.h
@@ -200,7 +200,7 @@ class ArbitraryImpl<T, std::enable_if_t<!std::is_const_v<T> &&
 };
 
 // Arbitrary for std::byte.
-template<>
+template <>
 class ArbitraryImpl<std::byte> : public DomainBase<ArbitraryImpl<std::byte>> {
  public:
   using typename ArbitraryImpl::DomainBase::corpus_type;
@@ -223,7 +223,7 @@ class ArbitraryImpl<std::byte> : public DomainBase<ArbitraryImpl<std::byte>> {
 
   auto GetPrinter() const { return IntegralPrinter{}; }
 
-private:
+ private:
   ArbitraryImpl<unsigned char> inner_;
 };
 


### PR DESCRIPTION
std::byte is not a character or arithmetic type, and so needs its own template specialization. This is implemented by simply wrapping an inner Arbitrary<unsigned char>.