### PR TITLE
#Centipede Add flag to pass arguments to the fuzz binary

### DIFF
--- a/centipede/centipede_callbacks.cc
+++ b/centipede/centipede_callbacks.cc
@@ -133,7 +133,7 @@ Command &CentipedeCallbacks::GetOrCreateCommandForBinary(
   const auto amortized_timeout =
       absl::Seconds(env_.timeout_per_batch) + absl::Seconds(5);
   Command &cmd = commands_.emplace_back(Command(
-      /*path=*/binary, /*args=*/{},
+      /*path=*/binary, /*args=*/env_.binary_args,
       /*env=*/env,
       /*out=*/execute_log_path_,
       /*err=*/execute_log_path_,
@@ -226,7 +226,7 @@ bool CentipedeCallbacks::GetSeedsViaExternalBinary(
   CHECK(std::filesystem::create_directories(output_dir, error));
   CHECK(!error);
 
-  Command cmd(binary, {},
+  Command cmd(binary, env_.binary_args,
               {absl::StrCat("CENTIPEDE_RUNNER_FLAGS=:dump_seed_inputs:arg1=",
                             output_dir.string(), ":")},
               /*out=*/execute_log_path_,

--- a/centipede/environment.h
+++ b/centipede/environment.h
@@ -39,6 +39,7 @@ struct Environment {
   std::string coverage_binary;
   std::string clang_coverage_binary;
   std::vector<std::string> extra_binaries;
+  std::vector<std::string> binary_args;
   std::string workdir;
   std::string merge_from;
   size_t num_runs = std::numeric_limits<size_t>::max();

--- a/centipede/environment_flags.cc
+++ b/centipede/environment_flags.cc
@@ -63,6 +63,8 @@ ABSL_FLAG(std::vector<std::string>, extra_binaries, default_env->extra_binaries,
           "fed the same inputs as the main binary, but the coverage feedback "
           "from them is not collected. Use this e.g. to run the target under "
           "sanitizers.");
+ABSL_FLAG(std::vector<std::string>, binary_args, default_env->binary_args,
+          "A comma-separated list of arguments passed to the binary.");
 ABSL_FLAG(std::string, workdir, default_env->workdir, "The working directory.");
 ABSL_FLAG(std::string, merge_from, default_env->merge_from,
           "Another working directory to merge the corpus from. Inputs from "
@@ -421,6 +423,7 @@ Environment CreateEnvironmentFromFlags(const std::vector<std::string> &argv) {
       .coverage_binary = coverage_binary,
       .clang_coverage_binary = absl::GetFlag(FLAGS_clang_coverage_binary),
       .extra_binaries = absl::GetFlag(FLAGS_extra_binaries),
+      .binary_args = absl::GetFlag(FLAGS_binary_args),
       .workdir = absl::GetFlag(FLAGS_workdir),
       .merge_from = absl::GetFlag(FLAGS_merge_from),
       .num_runs = absl::GetFlag(FLAGS_num_runs),


### PR DESCRIPTION
Enable passing flags to the binary (e.g. a fuzz test) as:
centipede --binary=/path/to/fuzztest --binary_args=--fuzz=MySuite.MyTest

Instead of previously:
centipede --binary="/path/to/fuzztest --fuzz=MySuite.MyTest"