### PR TITLE
Fix libFuzzer's compatibility mode

### DIFF
--- a/cmake/AddFuzzTest.cmake
+++ b/cmake/AddFuzzTest.cmake
@@ -9,6 +9,6 @@ function(link_fuzztest name)
       COMMAND bash -c "find $(${LLVM_CONFIG} --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a -o -name libclang_rt.fuzzer_no_main.a | head -1"
       OUTPUT_VARIABLE FUZZER_NO_MAIN OUTPUT_STRIP_TRAILING_WHITESPACE
     )
-    target_link_libraries(${name} PRIVATE ${FUZZER_NO_MAIN})
+    target_link_libraries(${name} PRIVATE -Wl,-whole-archive ${FUZZER_NO_MAIN} -Wl,-no-whole-archive)
   endif ()
 endfunction()

--- a/cmake/AddFuzzTest.cmake
+++ b/cmake/AddFuzzTest.cmake
@@ -6,7 +6,7 @@ function(link_fuzztest name)
         OUTPUT_VARIABLE LLVM_CONFIG OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     EXECUTE_PROCESS(
-      COMMAND bash -c "find $(${LLVM_CONFIG} --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a | head -1"
+      COMMAND bash -c "find $(${LLVM_CONFIG} --libdir) -name libclang_rt.fuzzer_no_main-x86_64.a -o -name libclang_rt.fuzzer_no_main.a | head -1"
       OUTPUT_VARIABLE FUZZER_NO_MAIN OUTPUT_STRIP_TRAILING_WHITESPACE
     )
     target_link_libraries(${name} PRIVATE ${FUZZER_NO_MAIN})


### PR DESCRIPTION
This PR solves two issues:
1. Finding the correct libFuzzer's runtime static libraries for recent LLVM releases
2. Ensuring that this library is linked with the `-whole-archive` flag to avoid undefined references to `LLVMFuzzerRunDriver`