### PR TITLE
Resolve CMake warning

### DIFF
--- a/cmake/BuildDependencies.cmake
+++ b/cmake/BuildDependencies.cmake
@@ -21,6 +21,11 @@ set(antlr_cpp_MD5 acf7371bd7562188712751266d8a7b90)
 set(nlohmann_json_URL https://github.com/nlohmann/json.git)
 set(nlohmann_json_TAG v3.11.2)
 
+if(POLICY CMP0135)
+	cmake_policy(SET CMP0135 NEW)
+	set(CMAKE_POLICY_DEFAULT_CMP0135 NEW)
+endif()
+
 if (FUZZTEST_BUILD_TESTING)
   FetchContent_Declare(
     nlohmann_json


### PR DESCRIPTION
From CMake 3.24, the CMP0135 policy behavior should be specified when using ExternalProject_Add function.

This is the CMP0135
documentation: https://cmake.org/cmake/help/latest/policy/CMP0135.html#policy:CMP0135

Using the NEW behavior for this policy will make sure the dependencies will be rebuilt whenever the URL changes.

Without this change, any client that takes a dependency on fuzztest will see these warnings in their CMake output, which is undesirable. Specifying the policy from the client code does not propagate too fuzztest's build, so this needs to occur inside of the fuzztest CMake build.