### PR TITLE
Use canonical way to find bash via /usr/bin/env

### DIFF
--- a/bazel/setup_configs.sh
+++ b/bazel/setup_configs.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Script for generating fuzztest.bazelrc.
 


### PR DESCRIPTION
The hardocded assumption that bash is to be found in /bin/bash does not alwyas hold true. On a Posix system, /usr/bin/env is the canonical way how to find the binary.

This shows up on operating systems that are very careful and specific about what executables to make available (such as NixOS).