### PR TITLE
[centipede] Fix build for string_view iter not being const char*

### DIFF
--- a/centipede/environment.cc
+++ b/centipede/environment.cc
@@ -92,7 +92,8 @@ static bool GetBoolFlag(std::string_view value) {
 // Returns `value` as a size_t, CHECK-fails on parse error.
 static size_t GetIntFlag(std::string_view value) {
   size_t result{};
-  CHECK(std::from_chars(value.begin(), value.end(), result).ec == std::errc())
+  CHECK(std::from_chars(value.data(), value.data() + value.size(), result).ec ==
+        std::errc())
       << value;
   return result;
 }

--- a/centipede/util.cc
+++ b/centipede/util.cc
@@ -352,7 +352,7 @@ bool ParseAFLDictionary(std::string_view dictionary_text,
     if (stop == start) return false;  // no closing "
     // Replace special characters and hex values.
     std::string replaced = absl::StrReplaceAll(
-        std::string_view(line.begin() + start, stop - start), replacements);
+        std::string_view(line.data() + start, stop - start), replacements);
     dictionary_entries.emplace_back(replaced.begin(), replaced.end());
   }
   return true;


### PR DESCRIPTION
V8 recently added fuzztest to their fuzzing infrastructure.
Similarly to fuzztest, V8 still builds with C++17.
There also was a recent change on libcxx changing the `string_view::iterator` to not be a raw pointer [[link](https://chromium.googlesource.com/external/github.com/llvm/llvm-project/libcxx/+/1486834cc84007f6786da316c1b9e0d0a9f11195)].

More details on the two changes:
`environment.cc`: Should fail if the `string_view` iterator is not implicitly convertible with `const char*`.
`util.cc`: The `string_view` constructor accepts both `const char*` as well as a contiguous iterator. However, the iterator overload was added in C++20, so it should not be used here.