### PR TITLE
Remove unnecessary linking instructions

### DIFF
--- a/doc/quickstart-cmake.md
+++ b/doc/quickstart-cmake.md
@@ -216,8 +216,6 @@ Congratulations! You're now all set for fuzzing with FuzzTest.
 **Warning:** compatibility mode is experimental and does not guarantee full
 FuzzTest features.
 
-Linking FuzzTest using `link_fuzztest()` enables linking with external fuzzing engines, when built with `-DFUZZTEST_COMPATIBILITY_MODE`.
-
 ```
 $ CC=clang CXX=clang++ cmake \
   -DCMAKE_BUILD_TYPE=RelWithDebug \


### PR DESCRIPTION
Remove unnecessary linking instructions from cmake quick-start for compatibility mode, which is no longer needed after https://github.com/google/fuzztest/commit/a53a2083e7df08749ea26b5960c05a9bffa186c2