### PR TITLE
Fix codelab CMakeLists.txt

### DIFF
--- a/codelab/CMakeLists.txt
+++ b/codelab/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 
 include(FetchContent)
 
-set(FUZZTEST_REPO_BRANCH "FuzzTest repository branch." CACHE STRING "main")
+set(FUZZTEST_REPO_BRANCH "main" CACHE STRING "FuzzTest repository branch.")
 message("Building fuzztest at branch " ${FUZZTEST_REPO_BRANCH})
 
 FetchContent_Declare(


### PR DESCRIPTION
Fix the parameter order of the set command by switching `value` and `docstring`.

See: https://cmake.org/cmake/help/latest/command/set.html `set(<variable> <value>... CACHE <type> <docstring>)`