### PR TITLE
Unify gcc and clang output

### DIFF
--- a/.github/workflows/cmake_test.yml
+++ b/.github/workflows/cmake_test.yml
@@ -91,8 +91,7 @@ jobs:
             -D CMAKE_BUILD_TYPE=RelWithDebug \
             -D FUZZTEST_BUILD_TESTING=on \
           && cmake --build build_gcc -j $(nproc)
-# TODO: Rewrite helper `PrintValue` to obtain same output under clang and gcc
-# && ctest --test-dir build_gcc -j $(nproc) --output-on-failure
+          && ctest --test-dir build_gcc -j $(nproc) --output-on-failure
       - name: Run end-to-end tests in fuzzing mode
         if: matrix.mode == 'fuzzing'
         run: |

--- a/e2e_tests/functional_test.cc
+++ b/e2e_tests/functional_test.cc
@@ -526,6 +526,10 @@ void ExpectStackLimitExceededMessage(absl::string_view std_err,
 }
 
 TEST_F(UnitTestModeTest, StackLimitWorks) {
+#if defined(__GNUC__)
+  GTEST_SKIP() << "No coverage instrumentation for GNU compiler yet: skipping the fuzzing mode "
+                  "crash finding tests. ";
+#endif
 #if defined(__has_feature)
 #if !__has_feature(coverage_sanitizer)
   GTEST_SKIP() << "No coverage instrumentation: skipping the stack limit test "
@@ -676,6 +680,10 @@ class FuzzingModeCommandLineInterfaceTest
  protected:
   void SetUp() override {
     GenericCommandLineInterfaceTest::SetUp();
+#if defined(__GNUC__)
+    GTEST_SKIP() << "No coverage instrumentation for GNU compiler yet: skipping the fuzzing mode "
+                    "crash finding tests. ";
+#endif
 #if defined(__has_feature)
 #if !__has_feature(coverage_sanitizer)
     GTEST_SKIP() << "No coverage instrumentation: skipping the fuzzing mode "
@@ -1211,6 +1219,10 @@ class FuzzingModeFixtureTest
     : public ::testing::TestWithParam<ExecutionModelParam> {
  protected:
   void SetUp() override {
+#if defined(__GNUC__)
+    GTEST_SKIP() << "No coverage instrumentation for GNU compiler yet: skipping the fuzzing mode "
+                    "crash finding tests. ";
+#endif
 #if defined(__has_feature)
 #if !__has_feature(coverage_sanitizer)
     GTEST_SKIP() << "No coverage instrumentation: skipping the fuzzing mode "
@@ -1346,6 +1358,10 @@ class FuzzingModeCrashFindingTest
     : public ::testing::TestWithParam<ExecutionModelParam> {
  protected:
   void SetUp() override {
+#if defined(__GNUC__)
+    GTEST_SKIP() << "No coverage instrumentation for GNU compiler yet: skipping the fuzzing mode "
+                    "crash finding tests. ";
+#endif
 #if defined(__has_feature)
 #if !__has_feature(coverage_sanitizer)
     GTEST_SKIP() << "No coverage instrumentation: skipping the fuzzing mode "

--- a/fuzztest/domain_core.h
+++ b/fuzztest/domain_core.h
@@ -116,8 +116,8 @@ class DomainBuilder {
           iter.second != nullptr && iter.second->has_value(),
           "Some domain is not set yet!");
     }
-    return OwningDomain<T>(GetIndirect<T>(name)->template GetAs<Domain<T>>(),
-                           std::move(domain_lookup_table_));
+    auto domain = GetIndirect<T>(name)->template GetAs<Domain<T>>();
+    return OwningDomain<T>(std::move(domain), std::move(domain_lookup_table_));
   }
 
  private:


### PR DESCRIPTION
Enable tests with g++ compiler. 

FuzzTest mode still not supported.