### PR TITLE
Adding an overload of ReadFilesFromDirectory that takes in a filename…

### DIFF
--- a/fuzztest/fuzztest_macros.h
+++ b/fuzztest/fuzztest_macros.h
@@ -16,6 +16,7 @@
 #define FUZZTEST_FUZZTEST_FUZZTEST_MACROS_H_
 
 #include <cstdint>
+#include <regex>
 #include <string>
 #include <string_view>
 #include <tuple>
@@ -126,6 +127,11 @@ namespace fuzztest {
 //     .WithSeeds(ReadFilesFromDirectory(kCorpusPath));
 std::vector<std::tuple<std::string>> ReadFilesFromDirectory(
     std::string_view dir);
+
+// Overload of ReadFilesFromDirectory() that filters files by their names using regex.
+// Example: ReadFilesFromDirectory(dir, ".*\\.der$") to read only .der files.
+std::vector<std::tuple<std::string>> ReadFilesFromDirectory(
+    std::string_view dir, std::string_view filename_pattern);
 
 // Returns parsed dictionary entries from fuzzer dictionary definition in the
 // format specified at https://llvm.org/docs/LibFuzzer.html#dictionaries.


### PR DESCRIPTION
- Adding an overload of ReadFilesFromDirectory() that takes in a filename_pattern as a second argument.
- I thought of not using regex at all and only using `entry.path().extension()` since my current use-case is for matching specific file extensions. But I went with regex since it gives more flexibility.
- I could add an entry for this in the documentation if wanted.
