### PR TITLE
Change bogus Abseil version to a real one

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,10 +19,10 @@ module(
     repo_name = "com_google_fuzztest",
 )
 
-# TODO(lszekeres): Change back from git_override to released version.
+# TODO(lszekeres): Update and remove override as soon as next release is cut.
 bazel_dep(
     name = "abseil-cpp",
-    version = "0.0.0",
+    version = "20250127.1",
 )
 git_override(
     module_name = "abseil-cpp",


### PR DESCRIPTION
Changes the bazel_dep on Abseil to a real version so the dependency graph is valid even if the right version isn't provided.