### PR TITLE
Disable fuzztest subprocess library on Apple tvOS

### DIFF
--- a/fuzztest/internal/subprocess.cc
+++ b/fuzztest/internal/subprocess.cc
@@ -34,6 +34,10 @@
 #include <utility>
 #include <vector>
 
+#if defined(__APPLE__)
+#include <TargetConditionals.h>
+#endif
+
 #include "absl/container/flat_hash_map.h"
 #include "absl/functional/function_ref.h"
 #include "absl/strings/str_cat.h"
@@ -49,8 +53,10 @@ extern char** environ;
 
 namespace fuzztest::internal {
 
-#if !defined(_MSC_VER) && !(defined(__ANDROID_MIN_SDK_VERSION__) && \
-                            __ANDROID_MIN_SDK_VERSION__ < 28)
+#if !defined(_MSC_VER) &&                     \
+    !(defined(__ANDROID_MIN_SDK_VERSION__) && \
+      __ANDROID_MIN_SDK_VERSION__ < 28) &&    \
+    !(defined(TARGET_OS_TV) && TARGET_OS_TV)
 
 TerminationStatus::TerminationStatus(int status) : status_(status) {}
 
@@ -335,6 +341,9 @@ TerminationStatus RunCommandWithOutputCallbacks(
   FUZZTEST_INTERNAL_CHECK(
       false,
       "Subprocess library not implemented on older Android NDK versions yet");
+#elif defined(TARGET_OS_TV) && TARGET_OS_TV
+  FUZZTEST_INTERNAL_CHECK(
+      false, "Subprocess library not implemented on Apple tvOS yet");
 #else
   SubProcess proc;
   return proc.Run(command_line, on_stdout_output, on_stderr_output, environment,


### PR DESCRIPTION
On tvOS, creating child processes is forbidden at an API level, so the
posix_spawn_* functions used by FuzzTest in the subprocess code cause
build errors.

This change disables the subprocess library on Apple tvOS to avoid
calling unsupported functions.

This isssue is similar to https://github.com/google/fuzztest/commit/b2220493586a1b96ff043cf27aaa6c24f0da8fb3

Co-Authored-By: kubo@igalia.com