### PR TITLE
Fix Windows-specific build issues in subprocess.cc

### DIFF
--- a/fuzztest/internal/subprocess.cc
+++ b/fuzztest/internal/subprocess.cc
@@ -47,9 +47,11 @@
 #include "absl/types/span.h"
 #include "./fuzztest/internal/logging.h"
 
+#if !defined(_MSC_VER)
 // Needed to pass the current environment to posix_spawn, which needs an
 // explicit envp without an option to inherit implicitly.
 extern char** environ;
+#endif
 
 namespace fuzztest::internal {
 
@@ -356,14 +358,14 @@ RunResults RunCommand(
     const std::optional<absl::flat_hash_map<std::string, std::string>>&
         environment,
     absl::Duration timeout) {
-  std::string stdout;
-  std::string stderr;
+  std::string stdout_str;
+  std::string stderr_str;
   auto status = RunCommandWithOutputCallbacks(
       command_line,
-      [&stdout](absl::string_view output) { stdout.append(output); },
-      [&stderr](absl::string_view output) { stderr.append(output); },
+      [&stdout_str](absl::string_view output) { stdout_str.append(output); },
+      [&stderr_str](absl::string_view output) { stderr_str.append(output); },
       environment, timeout);
-  return {std::move(status), std::move(stdout), std::move(stderr)};
+  return {std::move(status), std::move(stdout_str), std::move(stderr_str)};
 }
 
 }  // namespace fuzztest::internal


### PR DESCRIPTION
This PR resolves multiple Windows-specific build issues in `subprocess.cc`.

### Changes included:
- Renamed local variables `stdout` and `stderr` to avoid macro name conflicts on Windows.
- Added `#if !defined(_MSC_VER)` guard around `extern char** environ;` to prevent a `-Winconsistent-dllimport` warning due to CRT macro expansion.
- Ensured clean `clang-cl` compilation on Windows.