### PR TITLE
Ensure Corpus Telemetry is correctly collected

### DIFF
--- a/centipede/environment.cc
+++ b/centipede/environment.cc
@@ -73,7 +73,7 @@ const Environment &Environment::Default() {
 
 bool Environment::DumpCorpusTelemetryInThisShard() const {
   // Corpus stats are global across all shards on all machines.
-  return my_shard_index == 0 && telemetry_frequency != 0;
+  return my_shard_index == 0;
 }
 
 bool Environment::DumpRUsageTelemetryInThisShard() const {


### PR DESCRIPTION
Per #1790, the `DumpCorpusTelemetryInThisShard` function makes an unnecessary check that requires `telemetry_frequency != 0`. This however, affects the collection of before and after fuzzing telemetry.

This change updates `DumpCorpusTelemetryInThisShard` to mirror `DumpRUsageTelemetryInThisShard`, by avoiding a direct check of the `telemetry_frequency` flag in the function. This allows both kinds of telemetry to always be collected before and after fuzzing, when `MaybeGenerateTelemetry` is called directly.

For all other situations `MaybeGenerateTelemetryAfterBatch` is called before `MaybeGenerateTelemetry` is called, which ensures that `telemetry_frequency` is checked before generating intermediate telemetry.