### PR TITLE
Remove extra ';' in table_of_recent_compares.h

### DIFF
--- a/fuzztest/internal/table_of_recent_compares.h
+++ b/fuzztest/internal/table_of_recent_compares.h
@@ -216,7 +216,7 @@ class TableOfRecentlyComparedBuffers {
   // Constructs a buffer comparison table with the `compact` option: When it is
   // true, `GetRandomOffset()`/`GetRandomEntry()` would sample from inserted
   // offsets/entries, unless the table is empty.
-  explicit TableOfRecentlyComparedBuffers(bool compact) : compact_(compact) {};
+  explicit TableOfRecentlyComparedBuffers(bool compact) : compact_(compact) {}
 
   void Insert(const uint8_t* buf1, const uint8_t* buf2, size_t n) {
     if (!compact_) {


### PR DESCRIPTION
The patch
https://github.com/google/fuzztest/commit/8b93bbe62eb356e8555e44d3f1c2f418783e3adb introduced an extra ';' two weeks ago.

This causes chromium fuzztest autoroller to fail at the moment:
```
fuzztest/internal/table_of_recent_compares.h:219:79: error: extra ';' after member function definition [-Werror,-Wextra-semi]
  219 |   explicit TableOfRecentlyComparedBuffers(bool compact) : compact_(compact) {};
```

Bug: https://github.com/google/fuzztest/issues/1857
Bug: https://issues.chromium.org/issues/444348065
Fixed: https://github.com/google/fuzztest/issues/1857
Fixed: https://issues.chromium.org/issues/444348065