### PR TITLE
Fix Abseil lts_20250814 compatibility in subprocess.h

### DIFF
--- a/fuzztest/internal/subprocess.h
+++ b/fuzztest/internal/subprocess.h
@@ -109,7 +109,7 @@ TerminationStatus RunCommandWithCallbacks(
     absl::FunctionRef<void(absl::string_view)> on_stderr_output,
     absl::FunctionRef<bool()> should_stop = [] { return false; },
     const std::optional<absl::flat_hash_map<std::string, std::string>>&
-        environment = {{}});
+        environment = absl::flat_hash_map<std::string, std::string>{});
 
 // Runs `command_line` in a subprocess and returns the run results that captures
 // the stdout/stderr as strings. Environment variables
@@ -120,7 +120,7 @@ TerminationStatus RunCommandWithCallbacks(
 RunResults RunCommand(
     absl::Span<const std::string> command_line,
     const std::optional<absl::flat_hash_map<std::string, std::string>>&
-        environment = {{}},
+        environment = absl::flat_hash_map<std::string, std::string>{},
     absl::Duration timeout = absl::InfiniteDuration());
 
 }  // namespace fuzztest::internal


### PR DESCRIPTION
### Title  
**Fix Abseil lts_20250814 compatibility in `subprocess.h`**

---

### Description  

When bumping Abseil to `lts_20250814.0` in OR-Tools, we also had to bump Fuzztest to `2025-08-05` to avoid earlier compilation errors. However, this Fuzztest release introduced a new build failure when compiled with the updated Abseil headers:

```
error: no matching constructor for initialization of 'const std::optional<absl::flat_hash_map<std::string, std::string>>'
```
This was caused by the use of `={{}}` as a default argument in `subprocess.h`.  
With newer Abseil + Clang (C++17/20), initializer list deduction here no longer resolves cleanly into a `std::optional<absl::flat_hash_map<...>>`.  

---

### Fix  

Updated the function signatures in `subprocess.h` to use explicit default construction of the `flat_hash_map` instead of relying on `{{}}`:

```diff
- environment = {{}});
+ environment = absl::flat_hash_map<std::string, std::string>{});
and
- environment = {{}},
+ environment = absl::flat_hash_map<std::string, std::string>{},
```
This restores compatibility with Abseil lts_20250814.0 and allows Fuzztest to build successfully under both CMake and Bazel.
### Related Issues

Fixes: #[4768](https://github.com/google/or-tools/issues/4768)

### Reproducer & Verification:
https://github.com/google/or-tools/issues/4768#issuecomment-3315081548

## Notes
This patch makes Fuzztest compatible with Abseil lts_20250814.0.
Should unblock OR-Tools CI once merged.
