### PR TITLE
Fix initialisation and signed comparison warnings

### DIFF
--- a/fuzztest/internal/domains/map_impl.h
+++ b/fuzztest/internal/domains/map_impl.h
@@ -20,15 +20,15 @@
 #include <tuple>
 #include <type_traits>
 
+#include "absl/random/bit_gen_ref.h"
+#include "absl/status/status.h"
+#include "absl/strings/string_view.h"
 #include "./fuzztest/internal/domains/domain_base.h"
 #include "./fuzztest/internal/domains/serialization_helpers.h"
 #include "./fuzztest/internal/meta.h"
 #include "./fuzztest/internal/serialization.h"
 #include "./fuzztest/internal/status.h"
 #include "./fuzztest/internal/type_support.h"
-#include "absl/random/bit_gen_ref.h"
-#include "absl/status/status.h"
-#include "absl/strings/string_view.h"
 
 namespace fuzztest::internal {
 

--- a/fuzztest/internal/domains/value_mutation_helpers.h
+++ b/fuzztest/internal/domains/value_mutation_helpers.h
@@ -19,13 +19,13 @@
 #include <limits>
 #include <optional>
 
-#include "./fuzztest/internal/domains/mutation_metadata.h"
-#include "./fuzztest/internal/meta.h"
-#include "./fuzztest/internal/table_of_recent_compares.h"
 #include "absl/numeric/bits.h"
 #include "absl/numeric/int128.h"
 #include "absl/random/bit_gen_ref.h"
 #include "absl/random/random.h"
+#include "./fuzztest/internal/domains/mutation_metadata.h"
+#include "./fuzztest/internal/meta.h"
+#include "./fuzztest/internal/table_of_recent_compares.h"
 
 namespace fuzztest::internal {
 
@@ -65,15 +65,14 @@ void RunOne(absl::BitGenRef prng, F... f) {
 
 template <typename T, size_t N, typename F>
 T ChooseOneOr(const T (&values)[N], absl::BitGenRef prng, F f) {
-  const unsigned int i =
-      absl::Uniform<unsigned int>(absl::IntervalClosedClosed, prng, 0, N);
+  const auto i = absl::Uniform<size_t>(absl::IntervalClosedClosed, prng, 0, N);
   return i == N ? f() : values[i];
 }
 
 template <typename C, typename F>
 auto ChooseOneOr(const C& values, absl::BitGenRef prng, F f) {
-  const unsigned int i = absl::Uniform<unsigned int>(absl::IntervalClosedClosed,
-                                                     prng, 0, values.size());
+  const auto i =
+      absl::Uniform<size_t>(absl::IntervalClosedClosed, prng, 0, values.size());
   return i < values.size() ? values[i] : f();
 }
 


### PR DESCRIPTION
It happens so that, when enabling some warning lints such as incomplete initialisation and signed comparison, the public interface of the fuzztest library are rejected.

This patch fixes the issue.