### PR TITLE
correct name of the directory

### DIFF
--- a/doc/quickstart-cmake.md
+++ b/doc/quickstart-cmake.md
@@ -88,7 +88,7 @@ FuzzTest CMake already handles its dependencies on its own:
 With the CMake workspace set up, you can start using FuzzTest. Let's create a
 trivial example to make sure everything runs correctly.
 
-Create a file named `first_fuzz_test.cc` in the directory `first_fuzz` with the
+Create a file named `first_fuzz_test.cc` in the directory `first_fuzz_project` with the
 following contents:
 
 ```c++


### PR DESCRIPTION
next time consider using shorter and less dumb names in examples -- e.g. just 'test' instead 'my_first_fuzz_test_project_WOW_because_I_love_typing_shit_and_mixing_things_up'