### PR TITLE
Replace watchdog sleep with interruptable wait for faster teardown

### DIFF
--- a/fuzztest/internal/BUILD
+++ b/fuzztest/internal/BUILD
@@ -416,6 +416,7 @@ cc_library(
         "@abseil-cpp//absl/status:statusor",
         "@abseil-cpp//absl/strings",
         "@abseil-cpp//absl/strings:str_format",
+        "@abseil-cpp//absl/synchronization",
         "@abseil-cpp//absl/time",
         "@abseil-cpp//absl/types:span",
         "@com_google_fuzztest//common:bazel",

--- a/fuzztest/internal/CMakeLists.txt
+++ b/fuzztest/internal/CMakeLists.txt
@@ -393,6 +393,7 @@ fuzztest_cc_library(
     absl::statusor
     absl::strings
     absl::str_format
+    absl::synchronization
     absl::time
     absl::span
     fuzztest::bazel

--- a/fuzztest/internal/runtime.cc
+++ b/fuzztest/internal/runtime.cc
@@ -53,6 +53,7 @@
 #include "absl/strings/str_replace.h"
 #include "absl/strings/string_view.h"
 #include "absl/strings/strip.h"
+#include "absl/synchronization/notification.h"
 #include "absl/time/clock.h"
 #include "absl/time/time.h"
 #include "absl/types/span.h"
@@ -394,14 +395,14 @@ class Runtime::Watchdog {
   }
 
   ~Watchdog() {
-    stop_requested_ = true;
+    stop_.Notify();
     watchdog_thread_.join();
   }
 
  private:
   void WatchdogLoop() {
     watchdog_thread_started_ = true;
-    while (!stop_requested_) {
+    while (!stop_.HasBeenNotified()) {
       runtime_.CheckWatchdogLimits();
       runtime_.watchdog_spinlock_.Lock();
       if (runtime_.watchdog_limit_exceeded_) {
@@ -409,12 +410,13 @@ class Runtime::Watchdog {
         break;
       }
       runtime_.watchdog_spinlock_.Unlock();
-      absl::SleepFor(absl::Seconds(1));
+      // Wake on teardown via Notify(); the timeout keeps limit checks periodic.
+      stop_.WaitForNotificationWithTimeout(absl::Seconds(1));
     }
   }
 
   std::atomic<bool> watchdog_thread_started_ = false;
-  std::atomic<bool> stop_requested_ = false;
+  absl::Notification stop_;
   std::thread watchdog_thread_;
   Runtime& runtime_;
 };


### PR DESCRIPTION
## Summary

Make `Runtime::Watchdog` teardown prompt by replacing the fixed one-second sleep with an interruptible wait. I don't think there is a current issue open regarding this.

The previous loop used `absl::SleepFor(absl::Seconds(1))`; the destructor set a stop flag and then joined the thread. If the watchdog was mid-sleep, teardown blocked until that sleep returned, so binaries with many tests must unconditionally wait 1s per test at teardown, even if they finish processing before 1 second has passed.

This uses `absl::Notification`: the destructor's `Notify()` wakes the watchdog immediately, while `WaitForNotificationWithTimeout(absl::Seconds(1))` preserves the existing one-second periodic limit-check cadence.

## Testing
- 30 trivial `FUZZ_TEST`s in unit mode (`FUZZTEST_FUZZ_FOR=0`): total wall time 30.0s -> 0.01s (per-test teardown 1000ms -> 0ms).